### PR TITLE
use perl-install instead of perl-build

### DIFF
--- a/plenvsetup
+++ b/plenvsetup
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2016
 #
 # plenvsetup http://is.gd/plenvsetup
-# Wed Oct 16 14:44:22 JST 2019 v0.05 by ytnobody
+# Tue Jan 7 17:29:22 JST 2020 v0.05 by ytnobody
 #
 
 set -e
@@ -26,7 +26,7 @@ write_rc () {
 
 PLENV_REPO=git://github.com/tokuhirom/plenv.git
 PLENV_ROOT=$HOME/.plenv
-PERLBUILDER_REPO=git://github.com/tokuhirom/Perl-Build.git
+PERLBUILDER_REPO=https://github.com/skaji/perl-install
 PLENV_PLUGIN_DIR=$PLENV_ROOT/plugins
 
 if [ "$(echo "$SHELL" | sed -n '/\/bash$/p')" ]; then


### PR DESCRIPTION
@xtetsuji telling to me about perl-install in issue https://github.com/ytnobody/plenvsetup/issues/4

I tried to use perl-install instead of perl-build through plenvsetup. And it's simple.

I checked it works on a Docker container that is build from following Dockerfile.

```
FROM alpine

WORKDIR /root

RUN apk add bash libc-dev gcc make patch git curl
COPY plenvsetup plenvsetup

ENV SHELL=/bin/bash

RUN bash plenvsetup
RUN .plenv/bin/plenv install 5.24.1
RUN .plenv/bin/plenv global 5.24.1
RUN .plenv/bin/plenv rehash

CMD /bin/bash
```

@xtetsuji please review it and merge it if looks good to you. :)