### PR TITLE
change plenv clone protocol from Git to HTTPS

### DIFF
--- a/plenvsetup
+++ b/plenvsetup
@@ -24,7 +24,7 @@ write_rc () {
     fi
 }
 
-PLENV_REPO=git://github.com/tokuhirom/plenv.git
+PLENV_REPO=https://github.com/tokuhirom/plenv.git
 PLENV_ROOT=$HOME/.plenv
 PERLBUILDER_REPO=https://github.com/skaji/perl-install
 PLENV_PLUGIN_DIR=$PLENV_ROOT/plugins


### PR DESCRIPTION
GitHub disabled unauthenticated Git protocol recently.

- [Improving Git protocol security on GitHub | The GitHub Blog](https://github.blog/2021-09-01-improving-git-protocol-security-github/)